### PR TITLE
Add contributors page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2810,6 +2810,11 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA=="
     },
+    "@types/lodash": {
+      "version": "4.14.155",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.155.tgz",
+      "integrity": "sha512-vEcX7S7aPhsBCivxMwAANQburHBtfN9RdyXFk84IJmu2Z4Hkg1tOFgaslRiEqqvoLtbCBi6ika1EMspE+NZ9Lg=="
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^4.1.0",
+    "@types/lodash": "^4.14.155",
     "antd": "^4.2.0",
     "moment": "^2.24.0",
     "react": "^16.13.1",

--- a/src/App.css
+++ b/src/App.css
@@ -34,6 +34,10 @@ body {
   line-height: 2;
 }
 
+.font-small {
+  font-size: small;
+}
+
 .ant-layout-content {
   width: 100vw;
   display: flex;
@@ -46,11 +50,18 @@ body {
 
 .normal-width {
   max-width: 800px;
-  margin-bottom: 40px;
+}
+
+.margin-bottom {
+  margin-bottom: 20px;
 }
 
 .text-align-center {
   text-align: center;
+}
+
+.contributor {
+  min-width: 260px;
 }
 
 .button {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,24 +36,15 @@ function App() {
             </TopAppBarSection>
             <TopAppBarSection alignEnd>
               <nav>
-                <Link to="/directory">directory</Link>
                 <Link to="/">about</Link>
+                <Link to="/directory">directory</Link>
                 <Link to="/contributors">contributors</Link>
-                <Link to="/ideas">submit an idea</Link>
                 <a
                   href="https://discord.gg/pWF2zBf"
                   target="_blank"
                   rel="noreferrer noopener"
                 >
                   join us
-                </a>
-                <a
-                  href="https://twitter.com/ppeforfree"
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  className="icon icon-twitter"
-                >
-                  <img src="/twitter-icon.png" alt="twitter" />
                 </a>
                 <a
                   href="http://github.com/PPEForFree"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import {Alert, Layout} from "antd";
 
 // Pages
 import {About} from "./pages/about";
+import {Contributors} from "./pages/contributors";
 import {Ideas} from "./pages/ideas";
 import {InitiativeDirectory} from "./pages/initiatives";
 import {InitiativeSubmission} from "./pages/initiative-submission";
@@ -37,6 +38,7 @@ function App() {
               <nav>
                 <Link to="/directory">directory</Link>
                 <Link to="/">about</Link>
+                <Link to="/contributors">contributors</Link>
                 <Link to="/ideas">submit an idea</Link>
                 <a
                   href="https://discord.gg/pWF2zBf"
@@ -95,6 +97,7 @@ function App() {
             <Route path="/ideas" component={Ideas} />
             <Route path="/initiatives/submit" component={InitiativeSubmission} />
             <Route path="/directory" component={InitiativeDirectory} />
+            <Route path="/contributors" component={Contributors} />
             <Route path="/" component={About} />
           </Switch>
         </Content>

--- a/src/components/contributors/Contributors.tsx
+++ b/src/components/contributors/Contributors.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import _ from "lodash";
+import {Row, Col, Avatar} from "antd";
+
+export type PersonData = {
+  name: string;
+  location?: string;
+  url?: string;
+  avatarUrl?: string;
+  roles: string[];
+};
+
+export type OrganisationData = {
+  name: string;
+  url: string;
+  avatarUrl: string;
+};
+
+type ContributorsPeopleProps = {
+  people: PersonData[];
+};
+
+type ContributorsOrganisationProps = {
+  organisations: OrganisationData[];
+};
+
+type PersonProps = {
+  data: PersonData;
+};
+
+type OrganisationProps = {
+  data: OrganisationData;
+};
+
+const Person = ({data}: PersonProps) => (
+  <Col xs={24} sm={8} className="text-align-center margin-bottom contributor">
+    <div>
+      {data.avatarUrl ? (
+        <Avatar src={data.avatarUrl} size={64} />
+      ) : (
+        <Avatar size={64}>{data.name.charAt(0)}</Avatar>
+      )}
+    </div>
+    <div>
+      {data.url ? (
+        <a href={data.url} target="_blank">
+          {data.name}
+        </a>
+      ) : (
+        <>{data.name}</>
+      )}
+    </div>
+    <div>
+      {data.location ? `${data.location} - ` : ""}
+      {data.roles.join(", ")}
+    </div>
+  </Col>
+);
+
+const Organisation = ({data}: OrganisationProps) => (
+  <Col xs={24} sm={8} className="text-align-center margin-bottom contributor">
+    <div>
+      <Avatar src={data.avatarUrl} size={64} />
+    </div>
+    <div>
+      <a href={data.url} target="_blank">
+        {data.name}
+      </a>
+    </div>
+  </Col>
+);
+
+const PeopleRow = ({people}: ContributorsPeopleProps) => (
+  <Row
+    className="normal-width"
+    justify="center"
+    gutter={{xs: 8, sm: 16, md: 24, lg: 32}}
+    align="top"
+  >
+    {people.map((person) => (
+      <Person data={person} />
+    ))}
+  </Row>
+);
+
+export const ContributorsPeople = ({people}: ContributorsPeopleProps) => {
+  const groupedPeople = _.chunk(people, 5);
+
+  return (
+    <>
+      {groupedPeople.map((group) => {
+        const first = group.slice(0, 2);
+        const second = group.slice(2, 6);
+        return (
+          <>
+            <PeopleRow people={first} />
+            {second ? <PeopleRow people={second} /> : ""}
+          </>
+        );
+      })}
+    </>
+  );
+};
+
+export const ContributorsOrganisations = ({
+  organisations,
+}: ContributorsOrganisationProps) => {
+  return (
+    <>
+      {organisations.map((organisation) => (
+        <Organisation data={organisation} />
+      ))}
+    </>
+  );
+};

--- a/src/components/contributors/Contributors.tsx
+++ b/src/components/contributors/Contributors.tsx
@@ -43,7 +43,7 @@ const Person = ({data}: PersonProps) => (
     </div>
     <div>
       {data.url ? (
-        <a href={data.url} target="_blank">
+        <a href={data.url} target="_blank" rel="noopener noreferrer">
           {data.name}
         </a>
       ) : (
@@ -63,7 +63,7 @@ const Organisation = ({data}: OrganisationProps) => (
       <Avatar src={data.avatarUrl} size={64} />
     </div>
     <div>
-      <a href={data.url} target="_blank">
+      <a href={data.url} target="_blank" rel="noopener noreferrer">
         {data.name}
       </a>
     </div>
@@ -77,8 +77,8 @@ const PeopleRow = ({people}: ContributorsPeopleProps) => (
     gutter={{xs: 8, sm: 16, md: 24, lg: 32}}
     align="top"
   >
-    {people.map((person) => (
-      <Person data={person} />
+    {people.map((person, key) => (
+      <Person data={person} key={key} />
     ))}
   </Row>
 );
@@ -88,14 +88,14 @@ export const ContributorsPeople = ({people}: ContributorsPeopleProps) => {
 
   return (
     <>
-      {groupedPeople.map((group) => {
+      {groupedPeople.map((group, key) => {
         const first = group.slice(0, 2);
         const second = group.slice(2, 6);
         return (
-          <>
+          <React.Fragment key={key}>
             <PeopleRow people={first} />
             {second ? <PeopleRow people={second} /> : ""}
-          </>
+          </React.Fragment>
         );
       })}
     </>
@@ -107,8 +107,8 @@ export const ContributorsOrganisations = ({
 }: ContributorsOrganisationProps) => {
   return (
     <>
-      {organisations.map((organisation) => (
-        <Organisation data={organisation} />
+      {organisations.map((organisation, key) => (
+        <Organisation data={organisation} key={key} />
       ))}
     </>
   );

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -5,12 +5,12 @@ const {Title, Paragraph} = Typography;
 
 export const About = () => (
   <>
-    <Row className="normal-width" gutter={{xs: 8, sm: 16, md: 24, lg: 32}}>
+    <Row className="normal-width margin-bottom" gutter={{xs: 8, sm: 16, md: 24, lg: 32}}>
       <Col>
         <img src="/apple-icon.png" alt="PPEForFree Logo" />
       </Col>
     </Row>
-    <Row className="normal-width" gutter={{xs: 8, sm: 16, md: 24, lg: 32}}>
+    <Row className="normal-width margin-bottom" gutter={{xs: 8, sm: 16, md: 24, lg: 32}}>
       <Col>
         <Title level={1}>PPEForFree</Title>
         <Paragraph>

--- a/src/pages/contributors/index.tsx
+++ b/src/pages/contributors/index.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import {Row, Col, Typography} from "antd";
+import organisations from "./organisations.json";
+import people from "./people.json";
+import {
+  ContributorsOrganisations,
+  ContributorsPeople,
+} from "src/components/contributors/Contributors";
+
+const {Title, Paragraph} = Typography;
+
+export const Contributors = () => (
+  <>
+    <Row className="normal-width margin-bottom" gutter={{xs: 8, sm: 16, md: 24, lg: 32}}>
+      <Col>
+        <Title level={1}>Contributors</Title>
+        <Paragraph>
+          PPEForFree is built and maintained by a community of volunteers. Below is a list
+          of people who have donated their time and expertise to the project and
+          organisations who have donated resources.
+        </Paragraph>
+      </Col>
+    </Row>
+    <Row
+      className="normal-width margin-bottom text-align-center"
+      gutter={{xs: 8, sm: 16, md: 24, lg: 32}}
+    >
+      <Col>
+        <Title level={2}>People</Title>
+        <ContributorsPeople people={people} />
+      </Col>
+    </Row>
+    <Row
+      className="normal-width margin-bottom text-align-center"
+      gutter={{xs: 8, sm: 16, md: 24, lg: 32}}
+    >
+      <Col>
+        <Title level={2}>Organisations</Title>
+        <ContributorsOrganisations organisations={organisations} />
+      </Col>
+    </Row>
+  </>
+);

--- a/src/pages/contributors/organisations.json
+++ b/src/pages/contributors/organisations.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "Notion",
+    "url": "https://notion.so",
+    "avatarUrl": "https://upload.wikimedia.org/wikipedia/en/4/45/Notion_app_logo.png"
+  }
+]

--- a/src/pages/contributors/people.json
+++ b/src/pages/contributors/people.json
@@ -1,0 +1,48 @@
+[
+  {
+    "name": "Leon",
+    "location": "Angers, FR",
+    "url": "https://github.com/mindoodoo",
+    "avatarUrl": "https://avatars3.githubusercontent.com/u/10436331?s=460&u=c6a0f9ca1d07c53ddc6d64e9bb4b5d135e7817e6&v=4",
+    "roles": ["Project Lead"]
+  },
+  {
+    "name": "Elijah",
+    "location": "Kitchener, CA",
+    "url": "https://github.com/elijah-ward",
+    "avatarUrl": "https://avatars1.githubusercontent.com/u/17422956?s=460&u=2baea6458609c89c30a00569e16044d457b8808a&v=4",
+    "roles": ["Technical Lead", "Technical Contributor"]
+  },
+  {
+    "name": "Dragos",
+    "location": "Toronto, CA",
+    "url": "https://github.com/DragosRotaru",
+    "avatarUrl": "https://avatars2.githubusercontent.com/u/7482137?s=400&u=e443144a8ab9ada0f13cd7f1f7008b652819c154&v=4",
+    "roles": ["Founder", "Technical Contributor"]
+  },
+  {
+    "name": "Ollie",
+    "location": "London, UK",
+    "url": "https://github.com/ollie-codeaid",
+    "avatarUrl": "https://avatars3.githubusercontent.com/u/11909189?s=460&u=49046680eac3cedb7099a86616c1ab9df669c399&v=4",
+    "roles": ["Technical Contributor"]
+  },
+  {
+    "name": "Kurt",
+    "location": "Toronto, CA",
+    "url": "https://github.com/kurtvan",
+    "avatarUrl": "https://avatars1.githubusercontent.com/u/45082407?s=400&u=13a8474b98e6963def6968d4c3c54eeb5b20ec0b&v=4",
+    "roles": ["Technical Contributor"]
+  },
+  {
+    "name": "Michael",
+    "location": "Epsom, UK",
+    "url": "https://github.com/epsom-software",
+    "avatarUrl": "https://avatars3.githubusercontent.com/u/1492373?s=400&v=4",
+    "roles": ["Technical Contributor"]
+  },
+  {
+    "name": "Krysta",
+    "roles": ["Meta"]
+  }
+]

--- a/src/pages/initiatives/index.tsx
+++ b/src/pages/initiatives/index.tsx
@@ -30,7 +30,7 @@ const listItems = (items?: string[]) => {
 
 export const InitiativeDirectory = () => (
   <>
-    <Row className="normal-width" gutter={{xs: 8, sm: 16, md: 24, lg: 32}}>
+    <Row className="normal-width margin-bottom" gutter={{xs: 8, sm: 16, md: 24, lg: 32}}>
       <Col>
         <Title level={1}>PPEForFree Initiative Directory</Title>
         <Paragraph>


### PR DESCRIPTION
Sorry - really haven't had a great deal of time to spend on this.

I've pushed this very very basic mockup to facilitate some discussion. For the time being I've just put the contributors lists as a static json file. We could pull the technical contributors directly from github but I think it would be nice to have a little more control over name, role type etc.

For non-technical contributors and organisations we would eventually want some form of backend so that we can update without having to push code. For the time being I think this is fine though.